### PR TITLE
Add stops for Polregio ZKA on LK 201

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ To mark positions of bus replacements' stops, `highway=bus_stops` may be used.
 Such stops must have an `ref:station` node, with the ID of the parent station.
 If there are more than one replacement bus stops attached to a single station,
 direction hints (see (platform direction hints)[#direction-hints]) must be provided.
-If it's impossible to assign direction hints (ex. multiple stops in the same direction, but to different stations), `towards` tag should be used to indicate the station immediately following this station (see (section in stop positions)[#stop-positions]).
+If it's impossible to assign direction hints (ex. multiple stops in the same geographic direction, but to different stations), `towards` tag should be used to indicate the station immediately following this station. When using `towards` tag, stops with direction hints have to be provided in case matching by next stations is impossible.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ The following tags may be optionally provided:
 
 To mark positions of bus replacements' stops, `highway=bus_stops` may be used.
 Such stops must have an `ref:station` node, with the ID of the parent station.
+
 If there are more than one replacement bus stops attached to a single station,
-direction hints (see (platform direction hints)[#direction-hints]) must be provided.
-If it's impossible to assign direction hints (ex. multiple stops in the same geographic direction, but to different stations), `towards` tag should be used to indicate the station immediately following this station. When using `towards` tag, stops with direction hints have to be provided in case matching by next stations is impossible.
+direction hints (see (platform direction hints)[#direction-hints]) may
+be used to differentiate stops.
+
+In some cases, simple direction hints are not enough. In this case,
+the `towards` tag can be used to specify a `;`-separated list
+of station IDs immediately following this bus platform.
+
+When both `towards` and `direction` are present, both tags should be used for matching.
+Matches on `towards` should be preferred.
+
+For every given station, the following, rather complex rules apply:
+- If there is only one bus stop - it must not have any `direction` or `towards` hints.
+- Otherwise, if no bus stops use `towards` - all stops must have a `direction` tag,
+    and a single direction hint may only be present once.
+- Otherwise - at least one stop must have a `direction`, and a single direction hint may only be
+    present once, and a following station may only be present once.

--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ To mark positions of bus replacements' stops, `highway=bus_stops` may be used.
 Such stops must have an `ref:station` node, with the ID of the parent station.
 If there are more than one replacement bus stops attached to a single station,
 direction hints (see (platform direction hints)[#direction-hints]) must be provided.
+If it's impossible to assign direction hints (ex. multiple stops in the same direction, but to different stations), `towards` tag should be used to indicate the station immediately following this station (see (section in stop positions)[#stop-positions]).

--- a/scripts/loader.py
+++ b/scripts/loader.py
@@ -36,6 +36,7 @@ class BusStop(NamedTuple):
     id: str
     station: str
     direction_hints: list[str]
+    towards: list[str]
     position: Tuple[float, float]
 
 
@@ -126,6 +127,7 @@ class OSMLoader(SAXContentHandler):
                         station=station,
                         position=self.position,
                         direction_hints=osm_list(self.tags.get("direction", "")),
+                        towards=osm_list(self.tags.get("towards", "")),
                     )
                 )
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -387,18 +387,24 @@ def verify_bus_stops(
 
         # Check for direction hint existence requirement
         if len(bus_stops) == 1:
-            stop_hints = bus_stops[0].direction_hints
-            if stop_hints != [] and stop_hints != ["*"]:
-                issues.append(
-                    "The only bus stop has incomplete direction hint coverage: "
-                    f"{Color.yellow}{';'.join(stop_hints)}{Color.reset}. "
-                    f"Expected no hints, or sole {Color.yellow}*{Color.reset} hint."
-                )
+            if bus_stops[0].direction_hints:
+                issues.append("The only bus stop has direction hints - expected none")
+            if bus_stops[0].towards:
+                issues.append("The only bus stop has towards hints - expected none")
         else:
-            without_hints = [i for i in bus_stops if not i.direction_hints]
+            if all(not i.direction_hints for i in bus_stops):
+                issues.append(
+                    "No bus stop has a direction hint - "
+                    "at least one must be provided when matching on towards hints fails"
+                )
+
+            without_hints = [
+                i for i in bus_stops if not i.direction_hints and not i.towards
+            ]
             for bus_stop in without_hints:
                 issues.append(
-                    f"Bus stop {Color.blue}{bus_stop.id}{Color.reset} has no hints"
+                    f"Bus stop {Color.blue}{bus_stop.id}{Color.reset} "
+                    "has no direction or towards hints"
                 )
 
         # Validate direction hints
@@ -406,6 +412,15 @@ def verify_bus_stops(
             chain.from_iterable(i.direction_hints for i in bus_stops)
         )
         issues.extend(_validate_station_direction_hints(direction_hints))
+
+        # Validate towards hints
+        towards_hints = Counter(chain.from_iterable(i.towards for i in bus_stops))
+        for hint, count in towards_hints.items():
+            if count > 1:
+                issues.append(
+                    f"Towards hint {Color.blue}{hint}{Color.reset} used "
+                    f"{Color.yellow}{count}{Color.reset} times"
+                )
 
         # Print the collected issues
         if issues:
@@ -440,12 +455,12 @@ def _validate_station_direction_hints(direction_hints: "Counter[str]") -> list[s
         elif wildcard_used and hint in HEADING_HINTS:
             issues.append(
                 f"Uses both the {Color.yellow}*{Color.reset} and "
-                f"{Color.yellow}{hint}{Color.reset} hints"
+                f"{Color.yellow}{hint}{Color.reset} direction hints"
             )
 
         elif count > 1:
             issues.append(
-                f"Hint {Color.blue}{hint}{Color.reset} used "
+                f"Direction hint {Color.blue}{hint}{Color.reset} used "
                 f"{Color.yellow}{count}{Color.reset} times"
             )
 


### PR DESCRIPTION
Adds replacement bus stop locations for ZKA on LK 201, based on: https://polregio.pl/pl/dla-podroznych/informacje/zastepcza-komunikacja-autobusowa-zka-linia-kolejowa-nr-201/

Introduces new tag - `towards` for replacement bus stops, as multiple stations (Sławki, Kiełpino Kartuskie, Wieżyca) have two sets of bus stops: two stops for express bus (KZ3) and two stops for regular bus (KZ2), with great distance between them (see example below, south stops are used by KZ3 and north stops are used by KZ2).
<img width="1054" height="646" alt="image" src="https://github.com/user-attachments/assets/eae68c4c-521f-4739-87b1-f18e03fd9604" />

Complimentary change in GTFS: https://github.com/MKuranowski/PolishTrainsGTFS/pull/14